### PR TITLE
Suggest CORS proxy for event pictures

### DIFF
--- a/src/components/SidebarEvents.vue
+++ b/src/components/SidebarEvents.vue
@@ -125,7 +125,8 @@ const editEvent = (uid) => {
               créer un compte, comme
               <a href="https://postimages.org/" target="_blank" class="p-text-secondary"
                 >postimages.org</a
-              >.
+              >. Alternativement, vous pouvez utiliser un service proxy CORS comme 
+              <a href="https://corsproxy.io" target="_blank" class="p-text-secondary">CorsProxy</a>.
             </div>
           </OverlayPanel>
         </div>


### PR DESCRIPTION
Hi 👋 Thank you for this amazing tool !
It's more of a quick tip than an actual pull request. Using PostImage works but you can save some time and clicks by just using a CORS proxy service that is either self-hosted or in production (like [CorsProxy](https://corsproxy.io/)) so you would only need to prefix your intended picture URL with say `https://corsproxy.io/?url=`.